### PR TITLE
changed npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Apart from simply exposing ```git(dir, args, callback)``` there are a couple of 
 ## Installation
 
 ```bash
-npm install gitsync
+npm install gits
 ```
 
 ## Usage


### PR DESCRIPTION
`npm ERR! 404 'gitsync' is not in the npm registry.`

It should be
`npm install gits`
